### PR TITLE
support data redaction

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "cond",
     "encryptable",
     "encrypter",
-    "onramplab"
+    "onramplab",
+    "redactable"
   ]
 }

--- a/phpinsights.php
+++ b/phpinsights.php
@@ -62,8 +62,10 @@ return [
 
     'remove' => [
         SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff::class,
-        NunoMaduro\PhpInsights\Domain\Insights\ForbiddenNormalClasses::class,
         SlevomatCodingStandard\Sniffs\TypeHints\DisallowMixedTypeHintSniff::class,
+        SlevomatCodingStandard\Sniffs\Classes\SuperfluousExceptionNamingSniff::class,
+        NunoMaduro\PhpInsights\Domain\Insights\ForbiddenNormalClasses::class,
+        NunoMaduro\PhpInsights\Domain\Insights\ForbiddenTraits::class,
     ],
 
     'config' => [

--- a/src/Builders/ModelBuilder.php
+++ b/src/Builders/ModelBuilder.php
@@ -29,7 +29,7 @@ class ModelBuilder extends Builder
             /** @var string $parsedColumn */
             $parsedColumn = preg_replace("/^{$tableName}\./", '', $column);
 
-            if ($this->model->isSearchableEncryptedField($parsedColumn)) {
+            if ($this->model->isEncryptableField($parsedColumn, true)) {
                 $blindIndex = $this->model->generateBlindIndex($parsedColumn, $parsedValue);
 
                 $this->query->whereNested(

--- a/src/Concerns/Securable.php
+++ b/src/Concerns/Securable.php
@@ -34,6 +34,31 @@ trait Securable
         return $this->morphToMany(EncryptionKey::class, 'encryptable', 'model_has_encryption_keys');
     }
 
+    /**
+     * @return array<EncryptableField>
+     */
+    public function getEncryptableFields(): array
+    {
+        return Collection::make($this->encryptable ?? [])
+            ->map(function (array $field, string $name) {
+                return new EncryptableField([
+                    'name' => $name,
+                    'type' => $field['type'],
+                    'is_searchable' => data_get($field, 'searchable', false),
+                ]);
+            })
+            ->values()
+            ->toArray();
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRedactableFields(): array
+    {
+        return array_keys($this->redactable ?? []);
+    }
+
     public function isEncrypted(): bool
     {
         return (bool) $this->encryptionKeys->first();
@@ -163,24 +188,5 @@ trait Securable
     protected function getEncrypter(): Encrypter
     {
         return App::make(Encrypter::class, ['tableName' => $this->getTable(), 'fields' => $this->getEncryptableFields()]);
-    }
-
-    protected function getEncryptableFields(): array
-    {
-        return Collection::make($this->encryptable ?? [])
-            ->map(function (array $field, string $name) {
-                return new EncryptableField([
-                    'name' => $name,
-                    'type' => $field['type'],
-                    'is_searchable' => data_get($field, 'searchable', false),
-                ]);
-            })
-            ->values()
-            ->toArray();
-    }
-
-    protected function getRedactableFields(): array
-    {
-        return array_keys($this->redactable ?? []);
     }
 }

--- a/src/Concerns/Securable.php
+++ b/src/Concerns/Securable.php
@@ -48,6 +48,11 @@ trait Securable
         return (bool) $field;
     }
 
+    public function isRedactableField(string $fieldName): bool
+    {
+        return in_array($fieldName, $this->getRedactableFields());
+    }
+
     public function shouldBeEncryptable(): bool
     {
         return true;
@@ -133,5 +138,10 @@ trait Securable
             })
             ->values()
             ->toArray();
+    }
+
+    protected function getRedactableFields(): array
+    {
+        return array_keys($this->redactable ?? []);
     }
 }

--- a/src/Concerns/Securable.php
+++ b/src/Concerns/Securable.php
@@ -29,12 +29,17 @@ trait Securable
         static::$keyManager = App::make(KeyManager::class);
     }
 
+    /**
+     * Get encryption keys the model used
+     */
     public function encryptionKeys(): MorphToMany
     {
         return $this->morphToMany(EncryptionKey::class, 'encryptable', 'model_has_encryption_keys');
     }
 
     /**
+     * Get encryptable fields the model defined
+     *
      * @return array<EncryptableField>
      */
     public function getEncryptableFields(): array
@@ -52,6 +57,8 @@ trait Securable
     }
 
     /**
+     * Get redactable fields the model defined
+     *
      * @return array<string>
      */
     public function getRedactableFields(): array
@@ -59,11 +66,17 @@ trait Securable
         return array_keys($this->redactable ?? []);
     }
 
+    /**
+     * Determine if the model is encrypted
+     */
     public function isEncrypted(): bool
     {
         return (bool) $this->encryptionKeys->first();
     }
 
+    /**
+     * Determine if the given field is encryptable
+     */
     public function isEncryptableField(string $fieldName, ?bool $isSearchable = null): bool
     {
         $fields = Collection::make($this->getEncryptableFields())
@@ -76,16 +89,25 @@ trait Securable
         return (bool) $fields->first();
     }
 
+    /**
+     * Determine if the given field is redactable
+     */
     public function isRedactableField(string $fieldName): bool
     {
         return in_array($fieldName, $this->getRedactableFields());
     }
 
+    /**
+     * Determine if the model should be encryptable.
+     */
     public function shouldBeEncryptable(): bool
     {
         return true;
     }
 
+    /**
+     * Encrypt data of the model
+     */
     public function encrypt(): void
     {
         if (! $this->shouldBeEncryptable()) {
@@ -110,6 +132,9 @@ trait Securable
         $this->saveQuietly();
     }
 
+    /**
+     * Decrypt data of the model
+     */
     public function decrypt(): void
     {
         $encryptionKey = $this->encryptionKeys()->first();
@@ -125,6 +150,8 @@ trait Securable
     }
 
     /**
+     * Generate blind index value for the given field
+     *
      * @param mixed $value
      */
     public function generateBlindIndex(string $fieldName, $value): array
@@ -143,6 +170,8 @@ trait Securable
 
     /**
      * Create a new Eloquent query builder for the model.
+     *
+     * @see \Illuminate\Database\Eloquent\Model
      */
     public function newEloquentBuilder($query)
     {
@@ -151,6 +180,8 @@ trait Securable
 
     /**
      * Get an attribute from the model.
+     *
+     * @see \Illuminate\Database\Eloquent\Concerns\HasAttributes
      */
     public function getAttribute($key)
     {

--- a/src/Concerns/Securable.php
+++ b/src/Concerns/Securable.php
@@ -39,14 +39,16 @@ trait Securable
         return (bool) $this->encryptionKeys->first();
     }
 
-    public function isSearchableEncryptedField(string $fieldName): bool
+    public function isEncryptableField(string $fieldName, ?bool $isSearchable = null): bool
     {
-        $field = Collection::make($this->getEncryptableFields())
-            ->first(function (EncryptableField $field) use ($fieldName) {
-                return $field->name === $fieldName && $field->isSearchable;
-            });
+        $fields = Collection::make($this->getEncryptableFields())
+            ->filter(fn (EncryptableField $field) => $field->name === $fieldName);
 
-        return (bool) $field;
+        if (! is_null($isSearchable)) {
+            $fields = $fields->filter(fn (EncryptableField $field) => $field->isSearchable === $isSearchable);
+        }
+
+        return (bool) $fields->first();
     }
 
     public function isRedactableField(string $fieldName): bool
@@ -102,7 +104,7 @@ trait Securable
      */
     public function generateBlindIndex(string $fieldName, $value): array
     {
-        if (! $this->isSearchableEncryptedField($fieldName)) {
+        if (! $this->isEncryptableField($fieldName, true)) {
             throw new InvalidArgumentException("The [{$fieldName}] field is not a searchable encrypted field.");
         }
 

--- a/src/Contracts/Redactor.php
+++ b/src/Contracts/Redactor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Contracts;
+
+interface Redactor
+{
+    /**
+     * @param mixed $value
+     */
+    public function redact($value): string;
+}

--- a/src/Contracts/Redactor.php
+++ b/src/Contracts/Redactor.php
@@ -6,6 +6,8 @@ interface Redactor
 {
     /**
      * @param mixed $value
+     *
+     * @return mixed
      */
-    public function redact($value): string;
+    public function redact($value);
 }

--- a/src/Contracts/Securable.php
+++ b/src/Contracts/Securable.php
@@ -7,25 +7,58 @@ use OnrampLab\SecurityModel\ValueObjects\EncryptableField;
 
 interface Securable
 {
+    /**
+     * Get encryption keys the model used
+     */
     public function encryptionKeys(): MorphToMany;
 
+    /**
+     * Get encryptable fields the model defined
+     *
+     * @return array<EncryptableField>
+     */
     public function getEncryptableFields(): array;
 
+    /**
+     * Get redactable fields the model defined
+     *
+     * @return array<string>
+     */
     public function getRedactableFields(): array;
 
+    /**
+     * Determine if the model is encrypted
+     */
     public function isEncrypted(): bool;
 
+    /**
+     * Determine if the given field is encryptable
+     */
     public function isEncryptableField(string $fieldName, ?bool $isSearchable = null): bool;
 
+    /**
+     * Determine if the given field is redactable
+     */
     public function isRedactableField(string $fieldName): bool;
 
+    /**
+     * Determine if the model should be encryptable.
+     */
     public function shouldBeEncryptable(): bool;
 
+    /**
+     * Encrypt data of the model
+     */
     public function encrypt(): void;
 
+    /**
+     * Decrypt data of the model
+     */
     public function decrypt(): void;
 
     /**
+     * Generate blind index value for the given field
+     *
      * @param mixed $value
      */
     public function generateBlindIndex(string $field, $value): array;

--- a/src/Contracts/Securable.php
+++ b/src/Contracts/Securable.php
@@ -10,7 +10,7 @@ interface Securable
 
     public function isEncrypted(): bool;
 
-    public function isSearchableEncryptedField(string $fieldName): bool;
+    public function isEncryptableField(string $fieldName, ?bool $isSearchable = null): bool;
 
     public function isRedactableField(string $fieldName): bool;
 

--- a/src/Contracts/Securable.php
+++ b/src/Contracts/Securable.php
@@ -12,6 +12,8 @@ interface Securable
 
     public function isSearchableEncryptedField(string $fieldName): bool;
 
+    public function isRedactableField(string $fieldName): bool;
+
     public function shouldBeEncryptable(): bool;
 
     public function encrypt(): void;

--- a/src/Contracts/Securable.php
+++ b/src/Contracts/Securable.php
@@ -3,10 +3,15 @@
 namespace OnrampLab\SecurityModel\Contracts;
 
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use OnrampLab\SecurityModel\ValueObjects\EncryptableField;
 
 interface Securable
 {
     public function encryptionKeys(): MorphToMany;
+
+    public function getEncryptableFields(): array;
+
+    public function getRedactableFields(): array;
 
     public function isEncrypted(): bool;
 

--- a/src/Redactors/E164PhoneNumberRedactor.php
+++ b/src/Redactors/E164PhoneNumberRedactor.php
@@ -14,8 +14,10 @@ class E164PhoneNumberRedactor implements Redactor
 
     /**
      * @param mixed $value
+     *
+     * @return mixed
      */
-    public function redact($value): string
+    public function redact($value)
     {
         $isMatched = preg_match(self::PATTERN, (string) $value);
 
@@ -23,7 +25,7 @@ class E164PhoneNumberRedactor implements Redactor
             return $value;
         }
 
-        $callback = function (array $matches) {
+        $callback = static function (array $matches) {
             $character = '*';
             $replacement = Str::mask($matches[2], $character, 3, strlen($matches[2]) - 5);
 

--- a/src/Redactors/E164PhoneNumberRedactor.php
+++ b/src/Redactors/E164PhoneNumberRedactor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Redactors;
+
+use Illuminate\Support\Str;
+use OnrampLab\SecurityModel\Contracts\Redactor;
+
+/**
+ * Redact E.164 format phone number to keep first 3 numbers and last 2 numbers
+ */
+class E164PhoneNumberRedactor implements Redactor
+{
+    public const PATTERN = '/(\+?)(\d{10,14})/';
+
+    /**
+     * @param mixed $value
+     */
+    public function redact($value): string
+    {
+        $isMatched = preg_match(self::PATTERN, (string) $value);
+
+        if (! $isMatched) {
+            return $value;
+        }
+
+        $callback = function (array $matches) {
+            $character = '*';
+            $replacement = Str::mask($matches[2], $character, 3, strlen($matches[2]) - 5);
+
+            return "{$matches[1]}{$replacement}";
+        };
+
+        return preg_replace_callback(self::PATTERN, $callback, (string) $value);
+    }
+}

--- a/src/Redactors/EmailRedactor.php
+++ b/src/Redactors/EmailRedactor.php
@@ -14,8 +14,10 @@ class EmailRedactor implements Redactor
 
     /**
      * @param mixed $value
+     *
+     * @return mixed
      */
-    public function redact($value): string
+    public function redact($value)
     {
         $isMatched = preg_match(self::PATTERN, (string) $value);
 
@@ -23,7 +25,7 @@ class EmailRedactor implements Redactor
             return $value;
         }
 
-        $callback = function (array $matches) {
+        $callback = static function (array $matches) {
             $character = '*';
             $length = Str::length($matches[1]) >= 5 ?  Str::length($matches[1]) - 2 : null;
             $replacement = Str::mask($matches[1], $character, 1, $length);

--- a/src/Redactors/EmailRedactor.php
+++ b/src/Redactors/EmailRedactor.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Redactors;
+
+use Illuminate\Support\Str;
+use OnrampLab\SecurityModel\Contracts\Redactor;
+
+/**
+ * Redact email name to keep first initial and would keep last letter if it’s longer or equal to 5
+ */
+class EmailRedactor implements Redactor
+{
+    public const PATTERN = '/([\w.+-]+)(@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/';
+
+    /**
+     * @param mixed $value
+     */
+    public function redact($value): string
+    {
+        $isMatched = preg_match(self::PATTERN, (string) $value);
+
+        if (! $isMatched) {
+            return $value;
+        }
+
+        $callback = function (array $matches) {
+            $character = '*';
+            $length = Str::length($matches[1]) >= 5 ?  Str::length($matches[1]) - 2 : null;
+            $replacement = Str::mask($matches[1], $character, 1, $length);
+
+            return "{$replacement}{$matches[2]}";
+        };
+
+        return preg_replace_callback(self::PATTERN, $callback, (string) $value);
+    }
+}

--- a/src/Redactors/NameRedactor.php
+++ b/src/Redactors/NameRedactor.php
@@ -14,8 +14,10 @@ class NameRedactor implements Redactor
 
     /**
      * @param mixed $value
+     *
+     * @return mixed
      */
-    public function redact($value): string
+    public function redact($value)
     {
         $isMatched = preg_match(self::PATTERN, (string) $value);
 
@@ -23,7 +25,7 @@ class NameRedactor implements Redactor
             return $value;
         }
 
-        $callback = function (array $matches) {
+        $callback = static function (array $matches) {
             $character = '*';
             $length = Str::length($matches[0]) >= 5 ?  Str::length($matches[0]) - 2 : null;
 

--- a/src/Redactors/NameRedactor.php
+++ b/src/Redactors/NameRedactor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Redactors;
+
+use Illuminate\Support\Str;
+use OnrampLab\SecurityModel\Contracts\Redactor;
+
+/**
+ * Redact name to keep first initial and would keep last letter if it’s longer or equal to 5
+ */
+class NameRedactor implements Redactor
+{
+    public const PATTERN = "/[\p{L}]+(?:[-.' ][\p{L}]+[.]*)*/u";
+
+    /**
+     * @param mixed $value
+     */
+    public function redact($value): string
+    {
+        $isMatched = preg_match(self::PATTERN, (string) $value);
+
+        if (! $isMatched) {
+            return $value;
+        }
+
+        $callback = function (array $matches) {
+            $character = '*';
+            $length = Str::length($matches[0]) >= 5 ?  Str::length($matches[0]) - 2 : null;
+
+            return Str::mask($matches[0], $character, 1, $length);
+        };
+
+        return preg_replace_callback(self::PATTERN, $callback, (string) $value);
+    }
+}

--- a/src/Redactors/PhoneNumberRedactor.php
+++ b/src/Redactors/PhoneNumberRedactor.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Redactors;
+
+use Illuminate\Support\Str;
+use OnrampLab\SecurityModel\Contracts\Redactor;
+
+/**
+ * Redact US format phone number to keep first 3 numbers and last 2 numbers
+ */
+class PhoneNumberRedactor implements Redactor
+{
+    public const PATTERN = '/(\(?)(\d{3})(\)?[- ]?)(\d{3})([- ]?)(\d{4})/';
+
+    /**
+     * @param mixed $value
+     */
+    public function redact($value): string
+    {
+        $isMatched = preg_match(self::PATTERN, (string) $value);
+
+        if (! $isMatched) {
+            return $value;
+        }
+
+        $callback = function (array $matches) {
+            $character = '*';
+            $matches[4] = Str::mask($matches[4], $character, 0);
+            $matches[6] = Str::mask($matches[6], $character, 0, 2);
+            $tokens = array_slice($matches, 1);
+
+            return implode($tokens);
+        };
+
+        return preg_replace_callback(self::PATTERN, $callback, (string) $value);
+    }
+}

--- a/src/Redactors/PhoneNumberRedactor.php
+++ b/src/Redactors/PhoneNumberRedactor.php
@@ -14,8 +14,10 @@ class PhoneNumberRedactor implements Redactor
 
     /**
      * @param mixed $value
+     *
+     * @return mixed
      */
-    public function redact($value): string
+    public function redact($value)
     {
         $isMatched = preg_match(self::PATTERN, (string) $value);
 
@@ -23,7 +25,7 @@ class PhoneNumberRedactor implements Redactor
             return $value;
         }
 
-        $callback = function (array $matches) {
+        $callback = static function (array $matches) {
             $character = '*';
             $matches[4] = Str::mask($matches[4], $character, 0);
             $matches[6] = Str::mask($matches[6], $character, 0, 2);

--- a/src/Redactors/SecretRedactor.php
+++ b/src/Redactors/SecretRedactor.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Redactors;
+
+use Illuminate\Support\Str;
+use OnrampLab\SecurityModel\Contracts\Redactor;
+
+/**
+ * Redact all value content with mask charater
+ */
+class SecretRedactor implements Redactor
+{
+    public const PATTERN = '/\d{5}/';
+
+    /**
+     * @param mixed $value
+     */
+    public function redact($value): string
+    {
+        $character = '*';
+
+        return Str::mask((string) $value, $character, 0);
+    }
+}

--- a/src/Redactors/SecretRedactor.php
+++ b/src/Redactors/SecretRedactor.php
@@ -14,8 +14,10 @@ class SecretRedactor implements Redactor
 
     /**
      * @param mixed $value
+     *
+     * @return mixed
      */
-    public function redact($value): string
+    public function redact($value)
     {
         $character = '*';
 

--- a/src/Redactors/ZipCodeRedactor.php
+++ b/src/Redactors/ZipCodeRedactor.php
@@ -14,8 +14,10 @@ class ZipCodeRedactor implements Redactor
 
     /**
      * @param mixed $value
+     *
+     * @return mixed
      */
-    public function redact($value): string
+    public function redact($value)
     {
         $isMatched = preg_match(self::PATTERN, (string) $value);
 
@@ -23,7 +25,7 @@ class ZipCodeRedactor implements Redactor
             return $value;
         }
 
-        $callback = function (array $matches) {
+        $callback = static function (array $matches) {
             $character = '*';
 
             return Str::mask($matches[0], $character, 1, 3);

--- a/src/Redactors/ZipCodeRedactor.php
+++ b/src/Redactors/ZipCodeRedactor.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Redactors;
+
+use Illuminate\Support\Str;
+use OnrampLab\SecurityModel\Contracts\Redactor;
+
+/**
+ * Redact 5-digit zip code to keep first digit and last digit
+ */
+class ZipCodeRedactor implements Redactor
+{
+    public const PATTERN = '/\d{5}/';
+
+    /**
+     * @param mixed $value
+     */
+    public function redact($value): string
+    {
+        $isMatched = preg_match(self::PATTERN, (string) $value);
+
+        if (! $isMatched) {
+            return $value;
+        }
+
+        $callback = function (array $matches) {
+            $character = '*';
+
+            return Str::mask($matches[0], $character, 1, 3);
+        };
+
+        return preg_replace_callback(self::PATTERN, $callback, (string) $value);
+    }
+}

--- a/tests/Classes/User.php
+++ b/tests/Classes/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as BaseUser;
 use OnrampLab\SecurityModel\Concerns\Securable;
 use OnrampLab\SecurityModel\Contracts\Securable as SecurableContract;
+use OnrampLab\SecurityModel\Redactors\SecretRedactor;
 
 class User extends BaseUser implements SecurableContract
 {
@@ -20,6 +21,10 @@ class User extends BaseUser implements SecurableContract
 
     protected $encryptable = [
         'email' => ['type' => 'string', 'searchable' => true],
+    ];
+
+    protected $redactable = [
+        'email' => SecretRedactor::class,
     ];
 
     protected static function newFactory(): Factory

--- a/tests/Unit/Concerns/SecurableTest.php
+++ b/tests/Unit/Concerns/SecurableTest.php
@@ -85,10 +85,23 @@ class SecurableTest extends TestCase
 
     /**
      * @test
+     * @testWith ["email", true, true]
+     *           ["email", null, true]
+     *           ["phone", null, false]
+     */
+    public function is_encryptable_field_should_work(string $fieldName, ?bool $isSearchable, bool $expectedResult): void
+    {
+        $actualResult = $this->model->isEncryptableField($fieldName, $isSearchable);
+
+        $this->assertEquals($expectedResult, $actualResult);
+    }
+
+    /**
+     * @test
      * @testWith ["email", true]
      *           ["phone", false]
      */
-    public function is_redactable_fields_should_work(string $fieldName, bool $expectedResult): void
+    public function is_redactable_field_should_work(string $fieldName, bool $expectedResult): void
     {
         $actualResult = $this->model->isRedactableField($fieldName);
 

--- a/tests/Unit/Concerns/SecurableTest.php
+++ b/tests/Unit/Concerns/SecurableTest.php
@@ -85,6 +85,18 @@ class SecurableTest extends TestCase
 
     /**
      * @test
+     * @testWith ["email", true]
+     *           ["phone", false]
+     */
+    public function is_redactable_fields_should_work(string $fieldName, bool $expectedResult): void
+    {
+        $actualResult = $this->model->isRedactableField($fieldName);
+
+        $this->assertEquals($expectedResult, $actualResult);
+    }
+
+    /**
+     * @test
      */
     public function should_be_encrytable_should_work(): void
     {

--- a/tests/Unit/Concerns/SecurableTest.php
+++ b/tests/Unit/Concerns/SecurableTest.php
@@ -240,6 +240,28 @@ class SecurableTest extends TestCase
         $this->assertEquals($expectedModel && $expectedModel->id === $actualModel->id, $expectedResult);
     }
 
+    /**
+     * @test
+     */
+    public function get_redacted_attribute_should_work(): void
+    {
+        $this->model->encryptionKeys()->attach($this->encryptionKey->id);
+
+        $this->keyManagerMock
+            ->shouldReceive('decryptEncryptionKey')
+            ->andReturn($this->dataKey);
+
+        $this->encrypterMock
+            ->shouldReceive('decryptRow')
+            ->andReturn(['email' => $this->email]);
+
+        $this->model->decrypt();
+
+        $this->assertEquals($this->model->email, $this->email);
+        $this->assertEquals($this->model->email_redacted, Str::repeat('*', Str::length($this->email)));
+        $this->assertEquals($this->model->name_redacted, null);
+    }
+
     public function encryptedModelDataProvider(): array
     {
         return [

--- a/tests/Unit/Concerns/SecurableTest.php
+++ b/tests/Unit/Concerns/SecurableTest.php
@@ -3,6 +3,7 @@
 namespace OnrampLab\SecurityModel\Tests\Unit\Concerns;
 
 use Closure;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Hash;
@@ -81,6 +82,28 @@ class SecurableTest extends TestCase
         $this->model->encryptionKeys()->attach($this->encryptionKey->id);
 
         $this->assertTrue($this->model->isEncrypted());
+    }
+
+    /**
+     * @test
+     */
+    public function get_encryptable_fields_should_work(): void
+    {
+        $expectedResult = ['email'];
+        $actualResult = Collection::make($this->model->getEncryptableFields())->pluck('name')->toArray();
+
+        $this->assertEquals($expectedResult, $actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function get_redactable_fields_should_work(): void
+    {
+        $expectedResult = ['email'];
+        $actualResult = $this->model->getRedactableFields();
+
+        $this->assertEquals($expectedResult, $actualResult);
     }
 
     /**

--- a/tests/Unit/Redactors/E164PhoneNumberRedactorTest.php
+++ b/tests/Unit/Redactors/E164PhoneNumberRedactorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Tests\Unit\Redactors;
+
+use OnrampLab\SecurityModel\Redactors\E164PhoneNumberRedactor;
+use OnrampLab\SecurityModel\Tests\TestCase;
+
+class E164PhoneNumberRedactorTest extends TestCase
+{
+    private E164PhoneNumberRedactor $redactor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->redactor = $this->app->make(E164PhoneNumberRedactor::class);
+    }
+
+    /**
+     * @test
+     * @testWith ["+11234567890", "+112******90"]
+     *           ["+442223366555", "+442*******55"]
+     *           ["+886988777111", "+886*******11"]
+     *           ["11234567890", "112******90"]
+     */
+    public function redact_should_work(string $originalValue, string $expectedValue): void
+    {
+        $actualValue = $this->redactor->redact($originalValue);
+
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+}

--- a/tests/Unit/Redactors/EmailRedactorTest.php
+++ b/tests/Unit/Redactors/EmailRedactorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Tests\Unit\Redactors;
+
+use OnrampLab\SecurityModel\Redactors\EmailRedactor;
+use OnrampLab\SecurityModel\Tests\TestCase;
+
+class EmailRedactorTest extends TestCase
+{
+    private EmailRedactor $redactor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->redactor = $this->app->make(EmailRedactor::class);
+    }
+
+    /**
+     * @test
+     * @testWith ["john@example.net", "j***@example.net"]
+     *           ["smith@example.net", "s***h@example.net"]
+     *           ["hayden@example.com.tw", "h****n@example.com.tw"]
+     *           ["rachel-marie.garcia@example.net", "r*****************a@example.net"]
+     */
+    public function redact_should_work(string $originalValue, string $expectedValue): void
+    {
+        $actualValue = $this->redactor->redact($originalValue);
+
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+}

--- a/tests/Unit/Redactors/NameRedactorTest.php
+++ b/tests/Unit/Redactors/NameRedactorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Tests\Unit\Redactors;
+
+use OnrampLab\SecurityModel\Redactors\NameRedactor;
+use OnrampLab\SecurityModel\Tests\TestCase;
+
+class NameRedactorTest extends TestCase
+{
+    private NameRedactor $redactor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->redactor = $this->app->make(NameRedactor::class);
+    }
+
+    /**
+     * @test
+     * @testWith ["John", "J***"]
+     *           ["José", "J***"]
+     *           ["Smith", "S***h"]
+     *           ["Hayden O'Reilly", "H*************y"]
+     *           ["William Jr. Smith", "W***************h"]
+     *           ["Rachel-Marie Garcia", "R*****************a"]
+     */
+    public function redact_should_work(string $originalValue, string $expectedValue): void
+    {
+        $actualValue = $this->redactor->redact($originalValue);
+
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+}

--- a/tests/Unit/Redactors/PhoneNumberRedactorTest.php
+++ b/tests/Unit/Redactors/PhoneNumberRedactorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Tests\Unit\Redactors;
+
+use OnrampLab\SecurityModel\Redactors\PhoneNumberRedactor;
+use OnrampLab\SecurityModel\Tests\TestCase;
+
+class PhoneNumberRedactorTest extends TestCase
+{
+    private PhoneNumberRedactor $redactor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->redactor = $this->app->make(PhoneNumberRedactor::class);
+    }
+
+    /**
+     * @test
+     * @testWith ["(123) 456-7890", "(123) ***-**90"]
+     *           ["123-456-7890", "123-***-**90"]
+     *           ["123 456 7890", "123 *** **90"]
+     *           ["1234567890", "123*****90"]
+     */
+    public function redact_should_work(string $originalValue, string $expectedValue): void
+    {
+        $actualValue = $this->redactor->redact($originalValue);
+
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+}

--- a/tests/Unit/Redactors/SecretRedactorTest.php
+++ b/tests/Unit/Redactors/SecretRedactorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Tests\Unit\Redactors;
+
+use OnrampLab\SecurityModel\Redactors\SecretRedactor;
+use OnrampLab\SecurityModel\Tests\TestCase;
+
+class SecretRedactorTest extends TestCase
+{
+    private SecretRedactor $redactor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->redactor = $this->app->make(SecretRedactor::class);
+    }
+
+    /**
+     * @test
+     * @testWith ["John Smith", "**********"]
+     *           ["(123) 456-7890", "**************"]
+     *           ["97003", "*****"]
+     */
+    public function redact_should_work(string $originalValue, string $expectedValue): void
+    {
+        $actualValue = $this->redactor->redact($originalValue);
+
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+}

--- a/tests/Unit/Redactors/ZipCodeRedactorTest.php
+++ b/tests/Unit/Redactors/ZipCodeRedactorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OnrampLab\SecurityModel\Tests\Unit\Redactors;
+
+use OnrampLab\SecurityModel\Redactors\ZipCodeRedactor;
+use OnrampLab\SecurityModel\Tests\TestCase;
+
+class ZipCodeRedactorTest extends TestCase
+{
+    private ZipCodeRedactor $redactor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->redactor = $this->app->make(ZipCodeRedactor::class);
+    }
+
+    /**
+     * @test
+     * @testWith ["97003", "9***3"]
+     */
+    public function redact_should_work(string $originalValue, string $expectedValue): void
+    {
+        $actualValue = $this->redactor->redact($originalValue);
+
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+}


### PR DESCRIPTION
## Implementation

### Backend

1. add `Redactor` interface
   ```
   interface Redactor
   {
     public function redact(mixed $value): mixed;
   }
   ```
2. add build-in redactors
   1. phone number
   2. E.164 phone number
   3. email
   4. name
   5. zip code
   6. secret
3. support `$redactable` attribute on model
   ```php
   class User extends Model implements SecurableContract
   {
     use Securable;

     /**
      * The attributes that are needed to be redacted.
      * 
      * @var array
      */
     protected $redactable = [
       'phone' => PhoneNumberRedactor::class,
     ];
   }
   ```
4. override `getAttribute` method on model to access redacted field
   ```
   $model->email_redacted   // would be redacted value
   $model->email            // would be original value
   ```