### PR TITLE
support redaction cache

### DIFF
--- a/tests/Feature/Concerns/SecurableTest.php
+++ b/tests/Feature/Concerns/SecurableTest.php
@@ -90,4 +90,26 @@ class SecurableTest extends TestCase
 
         $model->delete();
     }
+
+    /**
+     * @test
+     */
+    public function get_redacted_attribute_should_save_cache(): void
+    {
+        $attributes = ['email' => 'test@gmail.com'];
+        $eloquentModel = User::factory()->create($attributes);
+        $databaseModel = DB::table($eloquentModel->getTable())->find($eloquentModel->id);
+
+        $this->assertNull($databaseModel->email_redacted);
+
+        $expectedValue = '**************';
+
+        $this->assertEquals($expectedValue, $eloquentModel->email_redacted);
+
+        $databaseModel = DB::table($eloquentModel->getTable())->find($eloquentModel->id);
+
+        $this->assertEquals($expectedValue, $databaseModel->email_redacted);
+
+        $eloquentModel->delete();
+    }
 }

--- a/tests/Migrations/2023_05_17_021954_add_email_redacted_column_to_users_table.php
+++ b/tests/Migrations/2023_05_17_021954_add_email_redacted_column_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('email_redacted')->nullable(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('email_redacted');
+        });
+    }
+};


### PR DESCRIPTION
## Implementation

### Backend

1. modify `Securable` trait to save redacted value into database when there is redacted field on table